### PR TITLE
Support for other Philomena project sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Derpibooru tagging helper
 
-This is a simple tool which can help you add more tags to the images when uploading to [Derpibooru](https://derpibooru.org).
+This is a simple tool which can help you add more tags to the images when uploading to [Derpibooru](https://derpibooru.org) and other [Philomena](https://github.com/derpibooru/philomena) based image boards.
 
 ## How to use?
 
@@ -8,7 +8,13 @@ Simply open [https://derpibooru-tagging-helper.netlify.app/](https://derpibooru-
 
 ## Running locally
 
-First, run the development server:
+If you don't have pnpm installed, you can install it from NPM:
+
+```bash
+npm install -g pnpm
+```
+
+Then, run the development server:
 
 ```bash
 pnpm dev
@@ -16,4 +22,4 @@ pnpm dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-This project uses some code from original [philomena](https://github.com/derpibooru/philomena) project.
+This project uses some code from original [Philomena](https://github.com/derpibooru/philomena) project.

--- a/app/components/description.tsx
+++ b/app/components/description.tsx
@@ -17,7 +17,9 @@ export const Description: React.FC<DescriptionProps> = ({ className }) => {
         <b>How to use: </b>
         Simply enter your tags and press &quot;Load related&quot; button and
         click on the tags you want to add. Repeat until you are satisfied with
-        the results. You can also paste tags copied from the site.
+        the results. You can also paste tags copied from the site. You can also
+        use the website dropdown to select a different philomena based image
+        board.
       </p>
       <p>
         <b>How it works: </b>

--- a/app/components/tag-input.tsx
+++ b/app/components/tag-input.tsx
@@ -6,20 +6,21 @@ import {
   ComboboxOption,
   ComboboxOptions,
 } from "@headlessui/react";
+import type { WebsiteConfig } from "./types";
 
 export interface TagInputProps {
   onAdd: (tag: string) => void;
   onDeletePrevious?: () => void;
-  selectedWebsite: string;
+  website: WebsiteConfig;
 }
 
 export const TagInput: React.FC<TagInputProps> = ({
   onAdd,
   onDeletePrevious,
-  selectedWebsite
+  website,
 }) => {
   const [query, setQuery] = useState("");
-  const suggestions = useAutocomplete(query, selectedWebsite);
+  const suggestions = useAutocomplete(query, website);
 
   return (
     <Combobox
@@ -37,7 +38,7 @@ export const TagInput: React.FC<TagInputProps> = ({
     >
       <ComboboxInput
         placeholder="add a tag"
-        className="border border-[#5f636a] bg-[#272d38] p-5px text-sm leading-[inherit] placeholder:text-inherit placeholder:opacity-[54%] focus:border-[#647493] focus:bg-[#313947] focus:outline-none"
+        className="border border-[#5f636a] bg-[#272d38] p-5px text-sm leading-[inherit] placeholder:text-inherit placeholder:opacity-[54%] focus:border-[#647493] focus:bg-[#313947] focus:outline-none focus:ring-0"
         value={query}
         onChange={(event) => setQuery(event.target.value)}
       />

--- a/app/components/tag-input.tsx
+++ b/app/components/tag-input.tsx
@@ -10,14 +10,16 @@ import {
 export interface TagInputProps {
   onAdd: (tag: string) => void;
   onDeletePrevious?: () => void;
+  selectedWebsite: string;
 }
 
 export const TagInput: React.FC<TagInputProps> = ({
   onAdd,
   onDeletePrevious,
+  selectedWebsite
 }) => {
   const [query, setQuery] = useState("");
-  const suggestions = useAutocomplete(query);
+  const suggestions = useAutocomplete(query, selectedWebsite);
 
   return (
     <Combobox

--- a/app/components/types.ts
+++ b/app/components/types.ts
@@ -1,0 +1,6 @@
+export type WebsiteConfig = {
+  name: string;
+  url: string;
+  /** "Everything" filter id */
+  filter: string;
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,7 +107,7 @@ export default function Home() {
       <Description className="mb-6" />
 
       <label htmlFor="website-select" className="block mb-2 text-[13px]">Choose a website:</label>
-      <select id="website-select" value={selectedWebsite} onChange={handleWebsiteChange} className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
+      <select id="website-select" value={selectedWebsite} onChange={handleWebsiteChange} className="border border-[#5f636a] bg-[#1d242f] text[#e0e0e0] text-sm hover:bg-[#313947] block w-full p-2.5">
         {websites.map(website => (
           <option key={website.url} value={website.url}>
             {website.name}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,9 +50,6 @@ export default function Home() {
 
   const websites = [
     { name: "Derpibooru", url: "https://derpibooru.org" },
-    { name: "Ponybooru", url: "https://ponybooru.org" },
-    { name: "Twibooru", url: "https://twibooru.org" },
-    { name: "Ponepics", url: "https://ponerpics.org/" },
     { name: "Furbooru", url: "https://furbooru.org" }
   ];
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typescript": "5.5.3"
   },
   "devDependencies": {
+    "@tailwindcss/forms": "^0.5.9",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.39",
     "prettier": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: 5.5.3
         version: 5.5.3
     devDependencies:
+      '@tailwindcss/forms':
+        specifier: ^0.5.9
+        version: 0.5.9(tailwindcss@3.4.4)
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.39)
@@ -275,6 +278,11 @@ packages:
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@tailwindcss/forms@0.5.9':
+    resolution: {integrity: sha512-tM4XVr2+UVTxXJzey9Twx48c1gcxFStqn1pQz0tRsX8o3DvxhN5oY5pvyAbUx7VTaZxpej4Zzvc6h+1RJBzpIg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20'
 
   '@tanstack/react-virtual@3.8.1':
     resolution: {integrity: sha512-dP5a7giEM4BQWLJ7K07ToZv8rF51mzbrBMkf0scg1QNYuFx3utnPUBPUHdzaowZhIez1K2XS78amuzD+YGRA5Q==}
@@ -1117,6 +1125,10 @@ packages:
     resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
     engines: {node: '>=8.6'}
 
+  mini-svg-data-uri@1.4.4:
+    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
+    hasBin: true
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1929,6 +1941,11 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
       tslib: 2.6.3
+
+  '@tailwindcss/forms@0.5.9(tailwindcss@3.4.4)':
+    dependencies:
+      mini-svg-data-uri: 1.4.4
+      tailwindcss: 3.4.4
 
   '@tanstack/react-virtual@3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -2986,6 +3003,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mini-svg-data-uri@1.4.4: {}
 
   minimatch@3.1.2:
     dependencies:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,5 +11,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@headlessui/tailwindcss")],
+  plugins: [require("@headlessui/tailwindcss"), require("@tailwindcss/forms")],
 };

--- a/utils/local-autocomplete/use-autocomplete.ts
+++ b/utils/local-autocomplete/use-autocomplete.ts
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 import { LocalAutocompleter } from "./local-autocompleter";
+import type { WebsiteConfig } from "@/app/components/types";
 
-export const useAutocomplete = (prefix: string | undefined, selectedWebsite: string) => {
+export const useAutocomplete = (
+  prefix: string | undefined,
+  website: WebsiteConfig,
+) => {
   const [autocompleter, setAutocompleter] = useState<LocalAutocompleter>();
 
   // Fetch completion file just like in philomena's code
@@ -9,13 +13,13 @@ export const useAutocomplete = (prefix: string | undefined, selectedWebsite: str
     const now = new Date();
     const cacheKey = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}`;
 
-    fetch(
-      `${selectedWebsite}/autocomplete/compiled?vsn=2&key=${cacheKey}`,
-      { credentials: "omit", cache: "force-cache" },
-    )
+    fetch(`${website.url}/autocomplete/compiled?vsn=2&key=${cacheKey}`, {
+      credentials: "omit",
+      cache: "force-cache",
+    })
       .then((resp) => resp.arrayBuffer())
       .then((buf) => setAutocompleter(new LocalAutocompleter(buf)));
-  }, [selectedWebsite]);
+  }, [website]);
 
   return (prefix && autocompleter?.topK(prefix, 5)) || [];
 };

--- a/utils/local-autocomplete/use-autocomplete.ts
+++ b/utils/local-autocomplete/use-autocomplete.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { LocalAutocompleter } from "./local-autocompleter";
 
-export const useAutocomplete = (prefix: string | undefined) => {
+export const useAutocomplete = (prefix: string | undefined, selectedWebsite: string) => {
   const [autocompleter, setAutocompleter] = useState<LocalAutocompleter>();
 
   // Fetch completion file just like in philomena's code
@@ -10,12 +10,12 @@ export const useAutocomplete = (prefix: string | undefined) => {
     const cacheKey = `${now.getUTCFullYear()}-${now.getUTCMonth()}-${now.getUTCDate()}`;
 
     fetch(
-      `https://derpibooru.org/autocomplete/compiled?vsn=2&key=${cacheKey}`,
+      `${selectedWebsite}/autocomplete/compiled?vsn=2&key=${cacheKey}`,
       { credentials: "omit", cache: "force-cache" },
     )
       .then((resp) => resp.arrayBuffer())
       .then((buf) => setAutocompleter(new LocalAutocompleter(buf)));
-  }, []);
+  }, [selectedWebsite]);
 
   return (prefix && autocompleter?.topK(prefix, 5)) || [];
 };


### PR DESCRIPTION
Not sure if you're open to adding other sites as an option but if you are, please merge this.

In this PR:
- Added the dropdown for selecting a Philomena site to target for the tag helper.
  - I added the sites derpibooru (default) and furbooru for now. ponybooru, twibooru and ponerpics don't support those API endpoints being called externally.
- Updated the page description to reflect the new dropdown.
- Fixed a null value issue in handleAdd.
  - Was throwing a "tag is null" if you begin to type something and then clear the input.
- Updated readme with instructions to install pnpm as I didn't know what that was and I figure other people won't either. Feel free to revert this if I'm just being dumb. 

Hope this is okay!